### PR TITLE
Target both clue/buzz-react ^1.0 and ^0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.3",
         "knplabs/packagist-api": "~1.0",
-        "clue/buzz-react": "^0.5",
+        "clue/buzz-react": "^1.0 || ^0.5",
         "rize/uri-template": "^0.3"
     },
     "autoload": {


### PR DESCRIPTION
Bumped into the issue where I wanted to use this package together with `clue/buzz-react` `^1.0`. Upon researching a PR I was pleasantly surprised that [`^1.0` is fully compatible with `^0.5`](https://github.com/clue/php-buzz-react/releases/tag/v1.0.0).