### PR TITLE
Support PHP 8 and run tests on PHPUnit 9

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.gitignore export-ignore
 /examples/ export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.0
           - 7.4
           - 7.3
           - 7.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           coverage: xdebug
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
+        if: ${{ matrix.php >= 7.3 }}
+      - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
+        if: ${{ matrix.php < 7.3 }}
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ $ composer require clue/packagist-api-react:^1.3
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.3 through current PHP 7+ and
+extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
 HHVM.
 It's *highly recommended to use PHP 7+* for this project.
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "rize/uri-template": "^0.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^6.0 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "autoload": {
         "psr-4": { "Clue\\React\\Packagist\\Api\\": "src/" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="Packagist React Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Packagist React Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -12,7 +12,10 @@ class ClientTest extends TestCase
     private $browser;
     private $client;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpClient()
     {
         $this->browser = $this->getMockBuilder('Clue\React\Buzz\Browser')->disableOriginalConstructor()->getMock();
         $this->browser->expects($this->any())->method('withBase')->willReturn($this->browser);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -46,7 +46,13 @@ class TestCase extends BaseTestCase
 
     protected function createCallableMock()
     {
-        return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
+            // PHPUnit 8.5+
+            return $this->getMockBuilder('stdClass')->addMethods(array('__invoke'))->getMock();
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 8.4
+            return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        }
     }
 
     protected function expectPromiseResolve($promise)


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0beta2-cli php vendor/bin/phpunit
PHPUnit 9.5.7 by Sebastian Bergmann and contributors.

..........                                                        10 / 10 (100%)

Time: 00:00.016, Memory: 6.00 MB

OK (10 tests, 44 assertions)
```

This pull request builds on top of #16.